### PR TITLE
Minor fixes

### DIFF
--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1033,34 +1033,30 @@ public:
                 assert(TopValue(1).Node() == node->AsOp()->gtOp1);
                 assert(TopValue(0).Node() == node->AsOp()->gtOp2);
 
-                GenTree* op1 = node->AsOp()->gtOp1;
-                GenTree* op2 = node->AsOp()->gtOp2;
-                bool rewrite = false;
+                Value& lhs = TopValue(1);
+                Value& rhs = TopValue(0);
 
-                if (op1->OperIs(GT_LCL_ADDR) && op2->IsIntegralConst(0))
-                {
-                    op1 = m_compiler->gtNewIconNode(1);
-                    op2->ChangeType(TYP_INT);
-                    rewrite = true;
-                }
-                else if (op2->OperIs(GT_LCL_ADDR) && op1->IsIntegralConst(0))
-                {
-                    op2 = m_compiler->gtNewIconNode(1);
-                    op1->ChangeType(TYP_INT);
-                    rewrite = true;
-                }
-
-                if (rewrite)
+                if ((lhs.IsAddress() && rhs.Node()->IsIntegralConst(0)) ||
+                    (rhs.IsAddress() && lhs.Node()->IsIntegralConst(0)))
                 {
                     JITDUMP("Rewriting known address-of comparison [%06u]\n", m_compiler->dspTreeID(node));
-                    node->AsOp()->gtOp1 = op1;
-                    node->AsOp()->gtOp2 = op2;
+                    *lhs.Use() = m_compiler->gtNewIconNode(0);
+                    *rhs.Use() = m_compiler->gtNewIconNode(node->OperIs(GT_EQ) ? 0 : 1);
+                    m_stmtModified = true;
+
+                    INDEBUG(TopValue(0).Consume());
+                    INDEBUG(TopValue(1).Consume());
+                    PopValue();
+                    PopValue();
+                }
+                else
+                {
+                    EscapeValue(TopValue(0), node);
+                    PopValue();
+                    EscapeValue(TopValue(0), node);
+                    PopValue();
                 }
 
-                INDEBUG(TopValue(0).Consume());
-                INDEBUG(TopValue(1).Consume());
-                PopValue();
-                PopValue();
                 break;
             }
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1041,7 +1041,7 @@ public:
                 {
                     JITDUMP("Rewriting known address-of comparison [%06u]\n", m_compiler->dspTreeID(node));
                     *lhs.Use() = m_compiler->gtNewIconNode(0);
-                    *rhs.Use() = m_compiler->gtNewIconNode(node->OperIs(GT_EQ) ? 0 : 1);
+                    *rhs.Use() = m_compiler->gtNewIconNode(1);
                     m_stmtModified = true;
 
                     INDEBUG(TopValue(0).Consume());

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -2550,6 +2550,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
     if (varDsc->lvStackAllocatedBox)
     {
         JITDUMP("  struct promotion of V%02u is disabled because it is a stack allocated box\n", lclNum);
+        return false;
     }
 
 #ifdef SWIFT_SUPPORT


### PR DESCRIPTION
Switch local morph to use its semantic reasoning about addresses in the `GT_EQ/GT_NE` cases. Add a missing `return false`.